### PR TITLE
Added 'safe apply' approach to avoid getting 'apply already in progress'...

### DIFF
--- a/js/angular.cloudinary.js
+++ b/js/angular.cloudinary.js
@@ -87,9 +87,16 @@
 
                         var wrapWithApply = function(callback) {
                             return function(e, cbdata) {
+                              var phase = scope.$root.$$phase;
+                              if (phase == "$apply")
+                              {
+                                callback(e, cbdata);
+                              } else {
                                 scope.$apply(function() {
                                     callback(e, cbdata);
                                 });
+                              }
+                              
                             }
                         }
                         // This wraps each function in data with an angular $apply()


### PR DESCRIPTION
... errors

I was seeing a "$apply already in progress error" on a page where I let the user upload documents. They can only upload one-at-a-time, and the error would happen on the SECOND upload.  I added this code which _seems_ to get around it.  It's based on a "safe" apply approach that I found in a couple of posts.

I don't have a great way to test it, so it's tested minimally.  In other words, my page is working.  If you have a better idea of why this happens,  I'd be glad to hear it.
