### PR TITLE
Update doc - Need to include 'formData' as key instead of 'params'

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ after you have retrieved signed params.
 ````javascript
 cloudinaryData = {
     url: https://api.cloudinary.com/v1_1/YOUR_CLOUD_NAME/auto/upload
-    params : {
+    formData: {
         timestamp : 1375363550;
         tags : sampleTag,
         api_key : YOUR_API_KEY,


### PR DESCRIPTION
I have been working with these directives on these days and I realised that it wasn't sending any data from **params** (just the file datas) until I found looking into the jQuery plugin that the key for uploading all the information was **formData**. After that change everything works as expected :)
