### PR TITLE
Add option for lazy initialization of cloudinary_js.

### DIFF
--- a/js/angular.cloudinary.js
+++ b/js/angular.cloudinary.js
@@ -119,7 +119,11 @@
 
         };
     })
-    .config(function() {
-        $.cloudinary.config(CLOUDINARY_CONFIG);
+    .run(function($window) {
+      // This initializes cloudinary_js iff the global CLOUDINARY_CONFIG is defined.
+      // Otherwise, if CLOUDINARY_CONFIG is not defined the application must manually init cloudinary_js.
+      if ($window.CLOUDINARY_CONFIG) {
+        $.cloudinary.config($window.CLOUDINARY_CONFIG);
+      }
     });
 }));


### PR DESCRIPTION
Prior to this change an error was thrown if CLOUDINARY_CONFIG was not
globally defined.  This allows the cloudinary_js module to be initialized from other sources, especially API calls that complete after the AngularJS application has started.
