### PR TITLE
Using inline array notation for DI

### DIFF
--- a/js/angular.cloudinary.js
+++ b/js/angular.cloudinary.js
@@ -119,11 +119,11 @@
 
         };
     })
-    .run(function($window) {
+    .run(['$window', function($window) {
       // This initializes cloudinary_js iff the global CLOUDINARY_CONFIG is defined.
       // Otherwise, if CLOUDINARY_CONFIG is not defined the application must manually init cloudinary_js.
       if ($window.CLOUDINARY_CONFIG) {
         $.cloudinary.config($window.CLOUDINARY_CONFIG);
       }
-    });
+    }]);
 }));


### PR DESCRIPTION
This is contrary to the previous implicit dependency on $window, which would cause errors when EG. trying to minify the directive. See the documentation for more information [1].

[1] https://docs.angularjs.org/guide/di
